### PR TITLE
Fix typo in chapter title

### DIFF
--- a/src/epub/text/chapter-1-10.xhtml
+++ b/src/epub/text/chapter-1-10.xhtml
@@ -10,7 +10,7 @@
 			<section id="chapter-1-10" epub:type="chapter">
 				<h3 epub:type="title">
 					<span epub:type="z3998:roman">X</span>
-					<span epub:type="subtitle">A Man of the Waters</span>
+					<span epub:type="subtitle">The Man of the Waters</span>
 				</h3>
 				<p>It was the ship’s commander who had just spoken.</p>
 				<p>At these words Ned Land stood up quickly. Nearly strangled, the steward staggered out at a signal from his superior; but such was the commander’s authority aboard his vessel, not one gesture gave away the resentment that this man must have felt toward the Canadian. In silence we waited for the outcome of this scene; Conseil, in spite of himself, seemed almost fascinated, I was stunned.</p>


### PR DESCRIPTION
I noticed this minor discrepancy between the wording in the table of contents ("The Man of the Waters") and the title of chapter 10 ("A Man of the Waters").
According to the [original on Project Gutenberg](https://www.gutenberg.org/files/2488/2488-h/2488-h.htm#1.10), the former is correct.