### PR TITLE
[Editorial] Fix Latin translation of Finis Poloniae

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -55,7 +55,7 @@
 					<p>Latin: “our sea.” (<abbr>Ed.</abbr>) <a href="chapter-2-7.xhtml#noteref-15" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-16" epub:type="endnote">
-					<p>Latin: “Save Poland’s borders.” (<abbr>Ed.</abbr>) <a href="chapter-2-8.xhtml#noteref-16" epub:type="backlink">↩</a></p>
+					<p>Latin: “The end of Poland.” (<abbr>Ed.</abbr>) <a href="chapter-2-8.xhtml#noteref-16" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-17" epub:type="endnote">
 					<p>Bailly believed that Atlantis was located at the North Pole! (<abbr>Ed.</abbr>) <a href="chapter-2-10.xhtml#noteref-17" epub:type="backlink">↩</a></p>


### PR DESCRIPTION
Source: https://www.porta-polonica.de/en/atlas-of-remembrance-places/finis-poloniae-1831
This is also confirmed by the Polish Wikipedia entry:
https://pl.wikipedia.org/wiki/Finis_Poloniae